### PR TITLE
Changed the flashlight behavior when a player dies

### DIFF
--- a/lua/autorun/sh_dynamic_flashlight.lua
+++ b/lua/autorun/sh_dynamic_flashlight.lua
@@ -50,7 +50,7 @@ if CLIENT then
 else
     hook.Add("PlayerSwitchFlashlight", "DynamicFlashlight.Switch", function(ply, state)
         ply:SetNWBool("DynamicFlashlight", not ply:GetNWBool("DynamicFlashlight"))
-        ply:EmitSound("items/flashlight1.wav", 60, 100)
+        ply:EmitSound("HL2Player.FlashLightOn")
 
         return false
     end)

--- a/lua/autorun/sh_dynamic_flashlight.lua
+++ b/lua/autorun/sh_dynamic_flashlight.lua
@@ -49,8 +49,13 @@ if CLIENT then
     end)
 else
     hook.Add("PlayerSwitchFlashlight", "DynamicFlashlight.Switch", function(ply, state)
-        ply:SetNWBool("DynamicFlashlight", not ply:GetNWBool("DynamicFlashlight"))
-        ply:EmitSound("HL2Player.FlashLightOn")
+        local isAlive = ply:Alive()
+
+        if isAlive then
+            ply:EmitSound("HL2Player.FlashLightOn")
+        end
+
+        ply:SetNWBool("DynamicFlashlight", isAlive and (not ply:GetNWBool("DynamicFlashlight")) or false)
 
         return false
     end)


### PR DESCRIPTION
As mentioned in the commits, the flashlight switching will only work if the player is alive. Also, when the player dies, the flashlight is automatically turned off like by default. This issue is regularly reported by some players in the addon comments, this pull request is supposed to solve it for real.