### PR TITLE
Added mod compatability for Player:FlashlightIsOn()

### DIFF
--- a/lua/autorun/sh_dynamic_flashlight.lua
+++ b/lua/autorun/sh_dynamic_flashlight.lua
@@ -55,3 +55,9 @@ else
         return false
     end)
 end
+
+local _ply = FindMetaTable( "Player" )
+
+_ply.FlashlightIsOn = function( self ) -- Overwrite the default function to preserve mod compatability
+	return self:GetNWBool("DynamicFlashlight")
+end


### PR DESCRIPTION
Edited the Metatable for player so that :FlashlightIsOn() checks "DynamicFlashlight" network bool, instead of the default behavior. This allows it to preserve compatibility with mods that rely on knowing if the flashlight is on or not